### PR TITLE
fpdf_bridge to use autoloader in TCPDF class exist check

### DIFF
--- a/src/fpdi_bridge.php
+++ b/src/fpdi_bridge.php
@@ -25,7 +25,7 @@
 //  https://github.com/hanneskod/fpdi/issues
 //
 namespace fpdi {
-    if (!class_exists('\\TCPDF', false)) {
+    if (!class_exists('\\TCPDF', true)) {
         class fpdi_bridge extends \fpdf\FPDF
         {
         }


### PR DESCRIPTION
autoloader is needed to succeed this class exists check when using TCPDF dependency managed by composer.