### PR TITLE
Fix strings conversion

### DIFF
--- a/dev/Converter.php
+++ b/dev/Converter.php
@@ -1,8 +1,9 @@
 <?php
 namespace fpdidev;
 
+use hanneskod\classtools\Transformer\Reader;
+use PhpParser\Parser;
 use Symfony\Component\Finder\Finder;
-use hanneskod\classtools\Iterator\SplFileInfo;
 
 class Converter
 {
@@ -19,6 +20,7 @@ class Converter
     {
         foreach ($this->finder as $fileInfo) {
             $fileInfo = new SplFileInfo($fileInfo);
+            $fileInfo->setReader(new Reader($fileInfo->getContents(), new Parser(new KeepOriginalValueLexer)));
             $output(
                 self::buildFilename($fileInfo),
                 $this->header . $this->writer->write($fileInfo->getReader()->readAll())

--- a/dev/FpdiWriter.php
+++ b/dev/FpdiWriter.php
@@ -12,7 +12,7 @@ class FpdiWriter extends Writer
 {
     public function __construct(NodeTraverser $traverser = null)
     {
-        parent::__construct($traverser);
+        parent::__construct($traverser, new KeepScalarStringsPrinter);
         $this->apply(new NodeStripper('Expr_Include'));
         $this->apply(new CommentStripper);
         $this->apply(new NamespaceWrapper('fpdi'));

--- a/dev/KeepOriginalValueLexer.php
+++ b/dev/KeepOriginalValueLexer.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace fpdidev;
+
+use PhpParser\Lexer\Emulative;
+use PhpParser\Parser;
+
+class KeepOriginalValueLexer extends Emulative
+{
+    public function getNextToken(&$value = null, &$startAttributes = null, &$endAttributes = null) {
+        $tokenId = parent::getNextToken($value, $startAttributes, $endAttributes);
+
+        if ($value === "preg_match_all") {
+            $x=8;
+        }
+        
+        if ($tokenId == Parser::T_CONSTANT_ENCAPSED_STRING || $tokenId == Parser::T_LNUMBER || $tokenId == Parser::T_DNUMBER) {
+            $endAttributes['originalValue'] = $value;
+        }
+
+        return $tokenId;
+    }
+}

--- a/dev/KeepScalarStringsPrinter.php
+++ b/dev/KeepScalarStringsPrinter.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace fpdidev;
+
+use hanneskod\classtools\Transformer\BracketingPrinter;
+use PhpParser\Node\Scalar\String_;
+
+class KeepScalarStringsPrinter extends BracketingPrinter
+{
+    public function pScalar_String(String_ $node) {
+        $originalValue = $node->getAttribute('originalValue');
+        
+        if ($originalValue !== null) {
+            return $this->pNoIndent($originalValue);
+        } else {
+            return '\'' . $this->pNoIndent(addcslashes($node->value, '\'\\')) . '\'';
+        }
+    }
+}

--- a/dev/SplFileInfo.php
+++ b/dev/SplFileInfo.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace fpdidev;
+
+use hanneskod\classtools\Iterator\SplFileInfo as BaseSplFileInfo;
+use hanneskod\classtools\Transformer\Reader;
+
+class SplFileInfo extends BaseSplFileInfo
+{
+    private $reader;
+    
+    /**
+     * @param Reader $reader
+     * @return SplFileInfo
+     */
+    public function setReader(Reader $reader): SplFileInfo
+    {
+        $this->reader = $reader;
+        return $this;
+    }
+
+    /**
+     * Get reader for the contents of this file
+     *
+     * @return Reader
+     */
+    public function getReader()
+    {
+        if (!isset($this->reader)) {
+            $this->reader = parent::getReader();
+        }
+
+        return $this->reader;
+    }
+}

--- a/dev/TcpdfResolver.php
+++ b/dev/TcpdfResolver.php
@@ -3,13 +3,19 @@ namespace fpdidev;
 
 use PhpParser\NodeVisitorAbstract;
 use PhpParser\Node;
-use PhpParser\Node\Scalar\String;
+use PhpParser\Node\Scalar\String_;
 
 class TcpdfResolver extends NodeVisitorAbstract
 {
     public function leaveNode(Node $node) {
-        if ($node instanceof String) {
-            return new String(preg_replace('/^TCPDF/', '\TCPDF', $node->value));
+        if ($node instanceof String_) {
+            $attributes = $node->getAttributes();
+            if (isset($attributes['originalValue'])) {
+                $attributes['originalValue'] = preg_replace('/^("|\')TCPDF/', '$1\\\\\\\\TCPDF', $attributes['originalValue']);
+            }
+            
+//            throw wsc;
+            return new String_($node->value, $attributes);
         }
     }
 }

--- a/src/FPDF_TPL.php
+++ b/src/FPDF_TPL.php
@@ -23,7 +23,7 @@ namespace fpdi {
         protected $_tpls = array();
         public $tpl = 0;
         protected $_inTpl = false;
-        public $tplPrefix = '/TPL';
+        public $tplPrefix = "/TPL";
         protected $_res = array();
         public $lastUsedTemplateData = array();
         public function beginTemplate($x = null, $y = null, $w = null, $h = null)
@@ -32,7 +32,7 @@ namespace fpdi {
                 throw new \LogicException('This method is only usable with FPDF. Use TCPDF methods startTemplate() instead.');
             }
             if ($this->page <= 0) {
-                throw new \LogicException('You have to add at least a page first!');
+                throw new \LogicException("You have to add at least a page first!");
             }
             if ($x == null) {
                 $x = 0;
@@ -142,7 +142,7 @@ namespace fpdi {
             if ($h == 0) {
                 $h = $w * $_h / $_w;
             }
-            return array('w' => $w, 'h' => $h);
+            return array("w" => $w, "h" => $h);
         }
         public function SetFont($family, $style = '', $size = null, $fontfile = '', $subset = 'default', $out = true)
         {
@@ -278,8 +278,7 @@ namespace fpdi {
         public function _out($s)
         {
             if ($this->state == 2 && $this->_inTpl) {
-                $this->_tpls[$this->tpl]['buffer'] .= $s . '
-';
+                $this->_tpls[$this->tpl]['buffer'] .= $s . "\n";
             } else {
                 parent::_out($s);
             }

--- a/src/FPDI.php
+++ b/src/FPDI.php
@@ -174,8 +174,7 @@ namespace fpdi {
                     } else {
                         $this->_writeValue($nObj[1]);
                     }
-                    $this->_out('
-endobj');
+                    $this->_out("\nendobj");
                     $this->_objStack[$filename][$n] = null;
                     unset($this->_objStack[$filename][$n]);
                     reset($this->_objStack[$filename]);
@@ -272,9 +271,7 @@ endobj');
                 if (is_subclass_of($this, '\\TCPDF')) {
                     $buffer = $this->_getrawstream($buffer);
                     $this->_out('/Length ' . strlen($buffer) . ' >>');
-                    $this->_out('stream
-' . $buffer . '
-endstream');
+                    $this->_out("stream\n" . $buffer . "\nendstream");
                 } else {
                     $this->_out('/Length ' . strlen($buffer) . ' >>');
                     $this->_putstream($buffer);
@@ -346,7 +343,7 @@ endstream');
                     $this->_writeValue($value[1]);
                     $this->_out('stream');
                     $this->_out($value[2][1]);
-                    $this->_straightOut('endstream');
+                    $this->_straightOut("endstream");
                     break;
                 case \fpdi\pdf_parser::TYPE_HEX:
                     $this->_straightOut('<' . $value[1] . '>');

--- a/src/FilterASCII85.php
+++ b/src/FilterASCII85.php
@@ -30,7 +30,7 @@ namespace fpdi {
                 if ($ch == $ord['~']) {
                     break;
                 }
-                if (preg_match('/^\\s$/', chr($ch))) {
+                if (preg_match('/^\s$/', chr($ch))) {
                     continue;
                 }
                 if ($ch == $ord['z'] && $state == 0) {
@@ -78,7 +78,7 @@ namespace fpdi {
         }
         public function encode($in)
         {
-            throw new \LogicException('ASCII85 encoding not implemented.');
+            throw new \LogicException("ASCII85 encoding not implemented.");
         }
     }
 }

--- a/src/FilterLZW.php
+++ b/src/FilterLZW.php
@@ -113,7 +113,7 @@ namespace fpdi {
         }
         public function encode($in)
         {
-            throw new \LogicException('LZW encoding not implemented.');
+            throw new \LogicException("LZW encoding not implemented.");
         }
     }
 }

--- a/src/fpdi_bridge.php
+++ b/src/fpdi_bridge.php
@@ -24,7 +24,7 @@ namespace fpdi {
         class fpdi_bridge extends \TCPDF
         {
             protected $_tpls = array();
-            public $tplPrefix = '/TPL';
+            public $tplPrefix = "/TPL";
             protected $_currentObjId;
             protected function _getxobjectdict()
             {
@@ -87,14 +87,12 @@ namespace fpdi {
                             case 'n':
                                 $out .= chr(10);
                                 break;
-                            case '':
-                                if ($count != $n - 1 && $s[$count + 1] == '
-') {
+                            case "\r":
+                                if ($count != $n - 1 && $s[$count + 1] == "\n") {
                                     $count++;
                                 }
                                 break;
-                            case '
-':
+                            case "\n":
                                 break;
                             default:
                                 if (ord($s[$count]) >= ord('0') && ord($s[$count]) <= ord('9')) {


### PR DESCRIPTION
Compilation breaks escaped string characters. The result is, that there are null bytes in compiled files and it does not work on some environments. This PR ensures, that strings will remain the same - with escaped characters.